### PR TITLE
Fix ensureFileExtension

### DIFF
--- a/packages/path/README.md
+++ b/packages/path/README.md
@@ -99,6 +99,8 @@ path.removeRelativeIndicator("./file.txt"); // "file.txt"
 // Add or ensure extensions
 path.addMissingExtension("/path/to/file", "txt"); // "/path/to/file.txt"
 path.ensureFileExtension("/path/to/file", ".txt"); // "/path/to/file.txt"
+// extension can be provided without leading dot
+path.ensureFileExtension("/path/to/file", "txt"); // "/path/to/file.txt"
 
 // Get file information
 path.filename("/path/to/file.txt"); // "file.txt"

--- a/packages/path/src/path.lib.test.ts
+++ b/packages/path/src/path.lib.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ensureFileExtension } from "./path.lib.ts";
+
+describe("ensureFileExtension", () => {
+  it("adds extension when missing", () => {
+    const result = ensureFileExtension("/path/to/file", ".txt");
+    assert.equal(result, "/path/to/file.txt");
+  });
+
+  it("does not duplicate existing extension", () => {
+    const result = ensureFileExtension("/path/to/file.txt", ".txt");
+    assert.equal(result, "/path/to/file.txt");
+  });
+
+  it("supports extension without leading dot", () => {
+    const result = ensureFileExtension("/path/to/file", "txt");
+    assert.equal(result, "/path/to/file.txt");
+  });
+});

--- a/packages/path/src/path.lib.ts
+++ b/packages/path/src/path.lib.ts
@@ -205,8 +205,11 @@ export function ensureFileExtension(
   extension: string,
 ): AnyPath;
 export function ensureFileExtension(filePath: AnyPath, extension: string) {
-  if (filePath.endsWith(extension)) return filePath;
-  return `${filePath}.${extension}`;
+  const normalizedExt = extension.startsWith(".")
+    ? extension
+    : `.${extension}`;
+  if (filePath.endsWith(normalizedExt)) return filePath;
+  return `${filePath}${normalizedExt}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix `ensureFileExtension` to avoid duplicate dots
- document usage without a leading dot
- add unit tests for `ensureFileExtension`

## Testing
- `node --experimental-strip-types --experimental-test-snapshots --no-warnings --test src/**/*.test.ts` *(fails: Cannot find package 'mime-types')*