### PR TITLE
Add pipeline package

### DIFF
--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -1,0 +1,6 @@
+# @synstack/pipeline
+
+Functional chainable pipelines for synchronous and asynchronous functions.
+
+This package lets you compose a sequence of transformations while preserving
+whether the resulting value is a `Promise` or not.

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@synstack/pipeline",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "1.0.0",
+  "description": "Composable function pipelines with type safety",
+  "keywords": [
+    "pipeline",
+    "functional",
+    "compose",
+    "typescript"
+  ],
+  "author": {
+    "name": "pAIrprog",
+    "url": "https://pairprog.io"
+  },
+  "homepage": "https://github.com/pAIrprogio/synscript/tree/main/packages/pipeline",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pAIrprogio/synscript.git",
+    "directory": "packages/pipeline"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "test:types": "tsc --noEmit",
+    "test:unit": "node --experimental-strip-types --experimental-test-snapshots --no-warnings --test src/**/*.test.ts",
+    "test:unit:watch": "node --experimental-strip-types --experimental-test-snapshots --no-warnings --watch --test --watch src/**/*.test.ts",
+    "test": "yarn test:types && yarn test:unit",
+    "prepare": "yarn test && yarn build"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/pipeline.index.d.ts",
+        "default": "./dist/pipeline.index.js"
+      },
+      "require": {
+        "types": "./dist/pipeline.index.d.cts",
+        "default": "./dist/pipeline.index.cjs"
+      }
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.18",
+    "tsup": "^8.4.0",
+    "typescript": "^5.8.3"
+  },
+  "files": [
+    "src/**/*.ts",
+    "!src/**/*.test.ts",
+    "dist/**/*"
+  ]
+}

--- a/packages/pipeline/src/pipeline.index.ts
+++ b/packages/pipeline/src/pipeline.index.ts
@@ -1,0 +1,1 @@
+export { pipeline, Pipeline } from "./pipeline.lib.ts";

--- a/packages/pipeline/src/pipeline.lib.test.ts
+++ b/packages/pipeline/src/pipeline.lib.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { assertType } from "../../shared/src/ts.utils.ts";
+import { pipeline } from "./pipeline.lib.ts";
+
+const _types = () => {
+  const syncPipeline = pipeline._((a: number) => a + 2)._((a) => a * 2);
+  assertType<number>(syncPipeline.apply(1));
+  assertType<number>(syncPipeline.$(1));
+
+  const asyncPipeline = pipeline
+    ._((a: number) => a + 2)
+    ._((a) => Promise.resolve(a * 2));
+  assertType<Promise<number>>(asyncPipeline.apply(1));
+  assertType<Promise<number>>(asyncPipeline.$(1));
+};
+
+describe("pipeline", () => {
+  it("chains synchronous functions", () => {
+    const p = pipeline._((a: number) => a + 2)._((a) => a * 2);
+    assert.equal(p.apply(2), 8);
+    assert.equal(p.$(3), 10);
+  });
+
+  it("handles async functions", async () => {
+    const p = pipeline
+      ._((a: number) => a + 2)
+      ._((a) => Promise.resolve(a * 2));
+    const res = p.apply(2);
+    assert.equal(res instanceof Promise, true);
+    assert.equal(await res, 8);
+  });
+
+  it("mixes async and sync steps", async () => {
+    const p = pipeline
+      ._((a: number) => Promise.resolve(a + 1))
+      ._((b) => b * 3);
+    const res = p.$(2);
+    assert.equal(res instanceof Promise, true);
+    assert.equal(await res, 9);
+  });
+});

--- a/packages/pipeline/src/pipeline.lib.ts
+++ b/packages/pipeline/src/pipeline.lib.ts
@@ -1,0 +1,36 @@
+export type PipelineFn<I, O> = (input: I) => O;
+
+export class Pipeline<I, O> {
+  private readonly fns: Array<(value: any) => any>;
+
+  public constructor(fns: Array<(value: any) => any>) {
+    this.fns = fns.slice();
+  }
+
+  public _<R>(fn: PipelineFn<O, R>): Pipeline<I, R> {
+    return new Pipeline<I, R>([...this.fns, fn]);
+  }
+
+  public apply(value: I): O {
+    let result: any = value;
+    for (const fn of this.fns) {
+      if (result instanceof Promise) {
+        result = result.then(fn);
+      } else {
+        const r = fn(result);
+        result = r;
+      }
+    }
+    return result as O;
+  }
+
+  public $(value: I): O {
+    return this.apply(value);
+  }
+}
+
+export const pipeline = {
+  _<I, O>(fn: PipelineFn<I, O>): Pipeline<I, O> {
+    return new Pipeline<I, O>([fn]);
+  },
+};

--- a/packages/pipeline/tsconfig.json
+++ b/packages/pipeline/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {}
+}

--- a/packages/pipeline/tsup.config.ts
+++ b/packages/pipeline/tsup.config.ts
@@ -1,0 +1,1 @@
+export { default } from "../../tsup.config.base.ts";


### PR DESCRIPTION
## Summary
- add new `pipeline` package for chaining functions while keeping sync/async behaviour
- provide tests for pipeline
- add compile-time type assertions for pipeline

## Testing
- `node --experimental-strip-types --experimental-test-snapshots --no-warnings --test packages/pipeline/src/**/*.test.ts`
- `npx tsc -p packages/pipeline/tsconfig.json --noEmit` *(fails: Cannot find module 'node:assert/strict')*